### PR TITLE
Adding public method to get messageCount for sideline queue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.appform.dropwizard.actors</groupId>
     <artifactId>dropwizard-rabbitmq-actors</artifactId>
-    <version>2.0.23-2</version>
+    <version>2.0.23-3</version>
     <name>Dropwizard RabbitMQ Bundle</name>
     <url>https://github.com/santanusinha/dropwizard-rabbitmq-actors</url>
     <description>Provides actor abstraction on RabbitMQ for dropwizard based projects.</description>

--- a/src/main/java/io/appform/dropwizard/actors/actor/BaseActor.java
+++ b/src/main/java/io/appform/dropwizard/actors/actor/BaseActor.java
@@ -136,6 +136,10 @@ public abstract class BaseActor<Message> implements Managed {
         return actorImpl.pendingMessagesCount();
     }
 
+    public final long pendingSidelineMessagesCount() {
+        return actorImpl.pendingSidelineMessagesCount();
+    }
+
     @Override
     public void start() throws Exception {
         actorImpl.start();

--- a/src/main/java/io/appform/dropwizard/actors/actor/UnmanagedBaseActor.java
+++ b/src/main/java/io/appform/dropwizard/actors/actor/UnmanagedBaseActor.java
@@ -128,6 +128,10 @@ public class UnmanagedBaseActor<Message> {
         return publishActor().pendingMessagesCount();
     }
 
+    public final long pendingSidelineMessagesCount() {
+        return publishActor().pendingSidelineMessagesCount();
+    }
+
     private UnmanagedPublisher<Message> publishActor() {
         if (isNull(publishActor)) {
             throw new NotImplementedException("PublishActor is not initialized");

--- a/src/main/java/io/appform/dropwizard/actors/base/UnmanagedPublisher.java
+++ b/src/main/java/io/appform/dropwizard/actors/base/UnmanagedPublisher.java
@@ -77,6 +77,15 @@ public class UnmanagedPublisher<Message> {
         return Long.MAX_VALUE;
     }
 
+    public final long pendingSidelineMessagesCount() {
+        try {
+            return publishChannel.messageCount(queueName + "_SIDELINE");
+        } catch (IOException e) {
+            log.error("Issue getting message count. Will return max", e);
+        }
+        return Long.MAX_VALUE;
+    }
+
     public void start() throws Exception {
         final String exchange = config.getExchange();
         final String dlx = config.getExchange() + "_SIDELINE";


### PR DESCRIPTION
Currently UnmangedPublisher.pendingMessagesCount() method is public which gives only the messagesCount for main queue and so adding a small change to get pendingSidelineMessagesCount() which will provide messageCount for sideline queue.