### PR TITLE
Add priority queue support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.appform.dropwizard.actors</groupId>
     <artifactId>dropwizard-rabbitmq-actors</artifactId>
-    <version>2.0.28-6</version>
+    <version>2.0.28-7</version>
     <name>Dropwizard RabbitMQ Bundle</name>
     <url>https://github.com/santanusinha/dropwizard-rabbitmq-actors</url>
     <description>Provides actor abstraction on RabbitMQ for dropwizard based projects.</description>
@@ -96,11 +96,11 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <dropwizard.version>2.0.28</dropwizard.version>
-        <lombok.version>1.18.22</lombok.version>
+        <lombok.version>1.18.26</lombok.version>
         <guava.version>31.0.1-jre</guava.version>
         <test.container.version>1.0.6</test.container.version>
         <okhttp.version>4.9.3</okhttp.version>
-        <amqp-client.version>5.14.1</amqp-client.version>
+        <amqp-client.version>5.17.0</amqp-client.version>
     </properties>
 
     <dependencyManagement>
@@ -233,7 +233,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.7</version>
+                <version>0.8.8</version>
                 <executions>
                     <execution>
                         <goals>

--- a/src/main/java/io/appform/dropwizard/actors/actor/ActorConfig.java
+++ b/src/main/java/io/appform/dropwizard/actors/actor/ActorConfig.java
@@ -53,6 +53,12 @@ public class ActorConfig {
     private boolean delayed = false;
 
     @Builder.Default
+    private boolean priorityQueue = false;
+
+    @Builder.Default
+    private int maxPriority = 10;
+
+    @Builder.Default
     private DelayType delayType = DelayType.DELAYED;
 
     @NotNull

--- a/src/main/java/io/appform/dropwizard/actors/connectivity/RMQConnection.java
+++ b/src/main/java/io/appform/dropwizard/actors/connectivity/RMQConnection.java
@@ -42,6 +42,7 @@ import javax.net.ssl.SSLContext;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.security.KeyStore;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -158,8 +159,10 @@ public class RMQConnection implements Managed {
 
     public Map<String, Object> rmqOpts(final ActorConfig actorConfig) {
         final Map<String, Object> ttlOpts = getActorTTLOpts(actorConfig.getTtlConfig());
+        final Map<String, Object> priorityOpts = getPriorityOpts(actorConfig);
         return ImmutableMap.<String, Object>builder()
                 .putAll(ttlOpts)
+                .putAll(priorityOpts)
                 .put("x-ha-policy", "all")
                 .put("ha-mode", "all")
                 .build();
@@ -168,8 +171,10 @@ public class RMQConnection implements Managed {
     public Map<String, Object> rmqOpts(final String deadLetterExchange,
                                        final ActorConfig actorConfig) {
         final Map<String, Object> ttlOpts = getActorTTLOpts(actorConfig.getTtlConfig());
+        final Map<String, Object> priorityOpts = getPriorityOpts(actorConfig);
         return ImmutableMap.<String, Object>builder()
                 .putAll(ttlOpts)
+                .putAll(priorityOpts)
                 .put("x-ha-policy", "all")
                 .put("ha-mode", "all")
                 .put("x-dead-letter-exchange", deadLetterExchange)
@@ -233,4 +238,15 @@ public class RMQConnection implements Managed {
         }
         return ttlOpts;
     }
+
+    private Map<String, Object> getPriorityOpts(final ActorConfig actorConfig) {
+        if(actorConfig.isPriorityQueue()) {
+            return ImmutableMap.<String, Object>builder()
+                    .put("x-max-priority", actorConfig.getMaxPriority())
+                    .build();
+        } else {
+            return Collections.emptyMap();
+        }
+    }
+
 }


### PR DESCRIPTION
RMQ supports priority queues from 3.5.0. There are plenty of use cases where this support can come in handy. Support for declaring a queue with priority queue support is required to leverage this feature. More about RMQ priority queue: https://www.rabbitmq.com/priority.html