### PR TITLE
Added custom tags support while registering consumer

### DIFF
--- a/src/main/java/io/appform/dropwizard/actors/actor/Actor.java
+++ b/src/main/java/io/appform/dropwizard/actors/actor/Actor.java
@@ -27,6 +27,7 @@ import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.Set;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * A simpler derivation of {@link BaseActor} to be used in most common actor use cases. This is managed by dropwizard.
@@ -63,7 +64,21 @@ public abstract class Actor<MessageType extends Enum<MessageType>, Message> exte
             ExceptionHandlingFactory exceptionHandlingFactory,
             Class<? extends Message> clazz,
             Set<Class<?>> droppedExceptionTypes) {
-        super(type.name(), config, connectionRegistry, mapper, retryStrategyFactory, exceptionHandlingFactory,
+        this(type, StringUtils.EMPTY, config, connectionRegistry, mapper, retryStrategyFactory, exceptionHandlingFactory,
+                clazz, droppedExceptionTypes);
+    }
+
+    protected Actor(
+            MessageType type,
+            String consumerTag,
+            ActorConfig config,
+            ConnectionRegistry connectionRegistry,
+            ObjectMapper mapper,
+            RetryStrategyFactory retryStrategyFactory,
+            ExceptionHandlingFactory exceptionHandlingFactory,
+            Class<? extends Message> clazz,
+            Set<Class<?>> droppedExceptionTypes) {
+        super(type.name(), consumerTag, config, connectionRegistry, mapper, retryStrategyFactory, exceptionHandlingFactory,
                 clazz, droppedExceptionTypes);
         this.type = type;
     }

--- a/src/main/java/io/appform/dropwizard/actors/actor/BaseActor.java
+++ b/src/main/java/io/appform/dropwizard/actors/actor/BaseActor.java
@@ -31,6 +31,7 @@ import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.ClassUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.Collections;
 import java.util.Date;
@@ -76,7 +77,7 @@ public abstract class BaseActor<Message> implements Managed {
         this.droppedExceptionTypes
                 = null == droppedExceptionTypes
                 ? Collections.emptySet() : droppedExceptionTypes;
-        actorImpl = new UnmanagedBaseActor<>(name, config, connection, mapper, retryStrategyFactory,
+        actorImpl = new UnmanagedBaseActor<>(name, StringUtils.EMPTY, config, connection, mapper, retryStrategyFactory,
                 exceptionHandlingFactory, clazz,
                 this::handle,
                 this::handleExpiredMessages,
@@ -92,10 +93,24 @@ public abstract class BaseActor<Message> implements Managed {
             ExceptionHandlingFactory exceptionHandlingFactory,
             Class<? extends Message> clazz,
             Set<Class<?>> droppedExceptionTypes) {
+        this(name, StringUtils.EMPTY, config, connectionRegistry, mapper, retryStrategyFactory,
+                exceptionHandlingFactory, clazz, droppedExceptionTypes);
+    }
+
+    protected BaseActor(
+            String name,
+            String consumerTag,
+            ActorConfig config,
+            ConnectionRegistry connectionRegistry,
+            ObjectMapper mapper,
+            RetryStrategyFactory retryStrategyFactory,
+            ExceptionHandlingFactory exceptionHandlingFactory,
+            Class<? extends Message> clazz,
+            Set<Class<?>> droppedExceptionTypes) {
         this.droppedExceptionTypes
                 = null == droppedExceptionTypes
                 ? Collections.emptySet() : droppedExceptionTypes;
-        actorImpl = new UnmanagedBaseActor<>(name, config, connectionRegistry, mapper, retryStrategyFactory,
+        actorImpl = new UnmanagedBaseActor<>(name, consumerTag, config, connectionRegistry, mapper, retryStrategyFactory,
                 exceptionHandlingFactory, clazz,
                 this::handle,
                 this::handleExpiredMessages,

--- a/src/main/java/io/appform/dropwizard/actors/base/utils/NamingUtils.java
+++ b/src/main/java/io/appform/dropwizard/actors/base/utils/NamingUtils.java
@@ -1,7 +1,10 @@
 package io.appform.dropwizard.actors.base.utils;
 
 import io.appform.dropwizard.actors.utils.CommonUtils;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.experimental.UtilityClass;
+import org.apache.commons.lang3.StringUtils;
 
 @UtilityClass
 public class NamingUtils {
@@ -34,5 +37,28 @@ public class NamingUtils {
 
     public String getSideline(String queueName) {
         return String.format("%s_%s", queueName, "SIDELINE");
+    }
+
+    public String generateConsumerTag(String inputConsumerTag, int consumerNumber) {
+        if (StringUtils.isBlank(inputConsumerTag)) {
+            return StringUtils.EMPTY;
+        }
+
+        // There is limitation of 255 chars for consumer tags. So, quietly picking first 250 chars from the input.
+        String tagPrefix = StringUtils.substring(inputConsumerTag, 0, 250);
+        return tagPrefix + "_" + consumerNumber;
+    }
+
+    /**
+     * Generates consumer tag with drove app and instance IDs.
+     * e.g. my-service-1_0_215_AI-65e301a5-0833-410a-aa18-22f811b71eff
+     * @return
+     */
+    public String populateDescriptiveConsumerTag() {
+        String droveAppId = System.getenv("DROVE_APP_ID");
+        String droveInstanceId = System.getenv("DROVE_INSTANCE_ID");
+        return Stream.of(droveAppId, droveInstanceId)
+                .filter(StringUtils::isNotBlank)
+                .collect(Collectors.joining("_"));
     }
 }

--- a/src/test/java/io/appform/dropwizard/actors/base/utils/NamingUtilsTest.java
+++ b/src/test/java/io/appform/dropwizard/actors/base/utils/NamingUtilsTest.java
@@ -1,11 +1,34 @@
 package io.appform.dropwizard.actors.base.utils;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
 
 public class NamingUtilsTest {
     @Test
     public void shouldReturnSidelineQueueName() {
-        Assert.assertEquals("app.TEST_QUEUE_SIDELINE", NamingUtils.getSideline("app.TEST_QUEUE"));
+        assertEquals("app.TEST_QUEUE_SIDELINE", NamingUtils.getSideline("app.TEST_QUEUE"));
     }
+
+    @Test
+    public void shouldGenerateEmptyConsumerTagWhenInputTagIsNull() {
+        assertEquals(StringUtils.EMPTY, NamingUtils.generateConsumerTag(null, 1));
+    }
+
+    @Test
+    public void shouldGenerateEmptyConsumerTagWhenInputTagIsEmpty() {
+        assertEquals(StringUtils.EMPTY, NamingUtils.generateConsumerTag(StringUtils.EMPTY, 1));
+    }
+
+    @Test
+    public void shouldGenerateEmptyConsumerTagWhenInputTagIsProvided() {
+        assertEquals("testConsumerTag_1", NamingUtils.generateConsumerTag("testConsumerTag", 1));
+    }
+
+    @Test
+    public void shouldPopulateEmptyConsumerTagIfEnvVarsNotSet() {
+        assertEquals(StringUtils.EMPTY, NamingUtils.populateDescriptiveConsumerTag());
+    }
+
 }


### PR DESCRIPTION
As of now, we are using by default randomly generated tags for consumers like the following:
![image](https://github.com/santanusinha/dropwizard-rabbitmq-actors/assets/3818619/3d17abbc-8abf-4b06-89ea-01f9ba6f49e4)

A couple of problems with this:
- After making any RMQ-specific code changes, if my application instances come up, I won't be able to identify how the consumers are doing on new instances. A possible workaround could be to get the IP address of the consumer node and look back to get to the individual instance which is a bit troublesome.
- We are not able to distinguish the consumer from different application versions. For e.g., we can have a tag pattern like userService-1.0.2 which will show the specific version a consumer belongs to.
- If we notice any issue with a particular consumer (very unlikely) then it's not easy to identify that specific instance, eventually making things difficult to debug.

With custom tags, devs can configure the pattern as per their need, like the one mentioned in below image specifies the following:
- application name
- version
- instance id
- individual consumer number on that specific instance

![image](https://github.com/santanusinha/dropwizard-rabbitmq-actors/assets/3818619/cf2f689e-d6f4-4817-a00c-3e6fbf5285f3)
