### PR TITLE
Added support for custom consumer tag

### DIFF
--- a/src/main/java/io/appform/dropwizard/actors/actor/ConsumerConfig.java
+++ b/src/main/java/io/appform/dropwizard/actors/actor/ConsumerConfig.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 
 @Data
 @Builder
@@ -18,5 +19,8 @@ public class ConsumerConfig {
     @NotNull
     @Valid
     private ConnectionIsolationStrategy connectionIsolationStrategy;
+
+    @Size(max = 250)
+    private String tagPrefix;
 
 }

--- a/src/main/java/io/appform/dropwizard/actors/base/UnmanagedConsumer.java
+++ b/src/main/java/io/appform/dropwizard/actors/base/UnmanagedConsumer.java
@@ -104,7 +104,8 @@ public class UnmanagedConsumer<Message> {
     private String getConsumerTag(int consumerIndex) {
         return Optional.ofNullable(config.getConsumer())
                 .map(ConsumerConfig::getTagPrefix)
-                .map(configuredTag -> configuredTag + "_" + consumerIndex)
+                .filter(StringUtils::isNotBlank)
+                .map(tagPrefix -> tagPrefix + "_" + consumerIndex)
                 .orElse(StringUtils.EMPTY);
     }
 }

--- a/src/test/java/io/appform/dropwizard/actors/connectivity/actor/TagsBasedConsumerTest.java
+++ b/src/test/java/io/appform/dropwizard/actors/connectivity/actor/TagsBasedConsumerTest.java
@@ -95,12 +95,24 @@ public class TagsBasedConsumerTest {
         assertEquals("Expected consumer tag not generated", StringUtils.EMPTY, actualTag);
     }
 
-    private UnmanagedConsumer<String> createConsumer(String consumerTag) throws IOException {
+    @Test
+    public void testStartWithEmptyNotNullTag() throws Exception {
+        final UnmanagedConsumer<String> consumer = createConsumer(StringUtils.EMPTY);
+        consumer.start();
+        ArgumentCaptor<String> consumerTagArgCaptor = ArgumentCaptor.forClass(String.class);
+        verify(channel, Mockito.times(1)).basicConsume(anyString(), anyBoolean(), consumerTagArgCaptor.capture(),
+                any(Consumer.class));
+        String actualTag = consumerTagArgCaptor.getValue();
+        assertNotNull(actualTag);
+        assertEquals("Expected consumer tag not generated", StringUtils.EMPTY, actualTag);
+    }
+
+    private UnmanagedConsumer<String> createConsumer(String tagPrefix) throws IOException {
         when(actorConfig.getConcurrency()).thenReturn(1);
         when(actorConfig.getPrefix()).thenReturn("test-prefix");
         when(actorConfig.isSharded()).thenReturn(false);
         when(actorConfig.getShardCount()).thenReturn(1);
-        when(actorConfig.getConsumer()).thenReturn(ConsumerConfig.builder().tagPrefix(consumerTag).build());
+        when(actorConfig.getConsumer()).thenReturn(ConsumerConfig.builder().tagPrefix(tagPrefix).build());
         when(rmqConnection.newChannel()).thenReturn(channel);
 
         when(retryStrategyFactory.create(any())).thenReturn(retryStrategy);

--- a/src/test/java/io/appform/dropwizard/actors/connectivity/actor/TagsBasedConsumerTest.java
+++ b/src/test/java/io/appform/dropwizard/actors/connectivity/actor/TagsBasedConsumerTest.java
@@ -1,0 +1,115 @@
+package io.appform.dropwizard.actors.connectivity.actor;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Consumer;
+import io.appform.dropwizard.actors.actor.ActorConfig;
+import io.appform.dropwizard.actors.actor.ConsumerConfig;
+import io.appform.dropwizard.actors.actor.MessageHandlingFunction;
+import io.appform.dropwizard.actors.base.UnmanagedConsumer;
+import io.appform.dropwizard.actors.connectivity.RMQConnection;
+import io.appform.dropwizard.actors.exceptionhandler.ExceptionHandlingFactory;
+import io.appform.dropwizard.actors.exceptionhandler.handlers.ExceptionHandler;
+import io.appform.dropwizard.actors.retry.RetryStrategy;
+import io.appform.dropwizard.actors.retry.RetryStrategyFactory;
+import java.io.IOException;
+import java.util.function.Function;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+public class TagsBasedConsumerTest {
+
+    private static final String TEST_CONSUMER_TAG = "test-tag";
+    @Mock
+    private ActorConfig actorConfig;
+
+    @Mock
+    private RMQConnection rmqConnection;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @Mock
+    private RetryStrategyFactory retryStrategyFactory;
+
+    @Mock
+    private RetryStrategy retryStrategy;
+
+    @Mock
+    private ExceptionHandlingFactory exceptionHandlingFactory;
+
+    @Mock
+    private ExceptionHandler exceptionHandler;
+
+    @Mock
+    private MessageHandlingFunction<String, Boolean> handlerFunction;
+
+    @Mock
+    private MessageHandlingFunction<String, Boolean> expiredMessageHandlingFunction;
+
+    @Mock
+    private Function<Throwable, Boolean> errorCheckFunction;
+
+    @Mock
+    private Channel channel;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void testStartWithConfiguredTag() throws Exception {
+        final UnmanagedConsumer<String> consumer = createConsumer(TEST_CONSUMER_TAG);
+        consumer.start();
+        ArgumentCaptor<String> consumerTagArgCaptor = ArgumentCaptor.forClass(String.class);
+        verify(channel, Mockito.times(1)).basicConsume(anyString(), anyBoolean(), consumerTagArgCaptor.capture(),
+                any(Consumer.class));
+        String actualTag = consumerTagArgCaptor.getValue();
+        assertNotNull(actualTag);
+        assertEquals("Expected consumer tag not generated", TEST_CONSUMER_TAG + "_1", actualTag);
+    }
+
+    @Test
+    public void testStartWithoutTag() throws Exception {
+        final UnmanagedConsumer<String> consumer = createConsumer(null);
+        consumer.start();
+        ArgumentCaptor<String> consumerTagArgCaptor = ArgumentCaptor.forClass(String.class);
+        verify(channel, Mockito.times(1)).basicConsume(anyString(), anyBoolean(), consumerTagArgCaptor.capture(),
+                any(Consumer.class));
+        String actualTag = consumerTagArgCaptor.getValue();
+        assertNotNull(actualTag);
+        assertEquals("Expected consumer tag not generated", StringUtils.EMPTY, actualTag);
+    }
+
+    private UnmanagedConsumer<String> createConsumer(String consumerTag) throws IOException {
+        when(actorConfig.getConcurrency()).thenReturn(1);
+        when(actorConfig.getPrefix()).thenReturn("test-prefix");
+        when(actorConfig.isSharded()).thenReturn(false);
+        when(actorConfig.getShardCount()).thenReturn(1);
+        when(actorConfig.getConsumer()).thenReturn(ConsumerConfig.builder().tagPrefix(consumerTag).build());
+        when(rmqConnection.newChannel()).thenReturn(channel);
+
+        when(retryStrategyFactory.create(any())).thenReturn(retryStrategy);
+        when(exceptionHandlingFactory.create(any())).thenReturn(exceptionHandler);
+
+        final UnmanagedConsumer<String> consumer = new UnmanagedConsumer<>("test-name", actorConfig, rmqConnection,
+                objectMapper, retryStrategyFactory, exceptionHandlingFactory, String.class, handlerFunction,
+                expiredMessageHandlingFunction, errorCheckFunction);
+
+        return consumer;
+    }
+}


### PR DESCRIPTION
As of now, we are using by default randomly generated tags for consumers like the following:
![image](https://github.com/santanusinha/dropwizard-rabbitmq-actors/assets/3818619/3d17abbc-8abf-4b06-89ea-01f9ba6f49e4)

A couple of problems with this:
- After making any RMQ-specific code changes, if my application instances come up, I won't be able to identify how the consumers are doing on new instances. A possible workaround could be to get the IP address of the consumer node and look back to get to the individual instance which is a bit troublesome.
- We are not able to distinguish the consumer from different application versions. For e.g., we can have a tag pattern like userService-1.0.2 which will show the specific version a consumer belongs to.
- If we notice any issue with a particular consumer (very unlikely) then it's not easy to identify that specific instance, eventually making things difficult to debug.

With custom tags, devs can configure the pattern as per their need, like the one mentioned in below image specifies the following:
- application name
- version
- instance id
- individual consumer number on that specific instance

![image](https://github.com/santanusinha/dropwizard-rabbitmq-actors/assets/3818619/cf2f689e-d6f4-4817-a00c-3e6fbf5285f3)


---

Sample usage in config:
```
actors:
  TEST-ACTOR:
    exchange: test-exchange
    delayed: false
    prefix: test
    concurrency: 1
    prefetchCount: 1
    consumer:
      connectionIsolationStrategy:
        isolationLevel: DEFAULT
      tag: test_${APP-NAME}_${APP-VERSION}_${APP-ID}
```

Generated consumer tag with above config:
![image](https://github.com/santanusinha/dropwizard-rabbitmq-actors/assets/3818619/59f4994c-cbc3-48d1-94c4-de199f1a84fa)
