### PR TITLE
Bug fix: Separate Default producer and consumer connections to allow recovery from flow control

### DIFF
--- a/src/main/java/io/appform/dropwizard/actors/ConnectionRegistry.java
+++ b/src/main/java/io/appform/dropwizard/actors/ConnectionRegistry.java
@@ -1,5 +1,6 @@
 package io.appform.dropwizard.actors;
 
+import com.google.common.base.Joiner;
 import io.appform.dropwizard.actors.common.Constants;
 import io.appform.dropwizard.actors.common.ErrorCode;
 import io.appform.dropwizard.actors.common.RabbitmqActorException;
@@ -47,7 +48,8 @@ public class ConnectionRegistry implements Managed {
 
         if (Constants.DEFAULT_CONNECTIONS.contains(connectionName)) {
             throw new RabbitmqActorException(ErrorCode.CONNECTION_NAME_RESERVED_FOR_INTERNAL_USE,
-                    "Please don't use default connection names", null);
+                    String.format("These connection names are reserved for internal usage: [%s]",
+                            Joiner.on(',').join(Constants.DEFAULT_CONNECTIONS)), null);
         }
 
         return connections.computeIfAbsent(connectionName, connection -> {

--- a/src/main/java/io/appform/dropwizard/actors/ConnectionRegistry.java
+++ b/src/main/java/io/appform/dropwizard/actors/ConnectionRegistry.java
@@ -63,7 +63,8 @@ public class ConnectionRegistry implements Managed {
     }
 
     private int determineThreadPoolSize(String connectionName) {
-        if (Objects.equals(connectionName, Constants.DEFAULT_CONNECTION_NAME)) {
+        if (Objects.equals(connectionName, Constants.DEFAULT_PRODUCER_CONNECTION_NAME) ||
+                Objects.equals(connectionName, Constants.DEFAULT_CONSUMER_CONNECTION_NAME)) {
             return rmqConfig.getThreadPoolSize();
         }
 

--- a/src/main/java/io/appform/dropwizard/actors/RabbitmqActorBundle.java
+++ b/src/main/java/io/appform/dropwizard/actors/RabbitmqActorBundle.java
@@ -63,8 +63,12 @@ public abstract class RabbitmqActorBundle<T extends Configuration> implements Co
 
     }
 
-    public RMQConnection getConnection() {
-        return connectionRegistry.createOrGet(Constants.DEFAULT_CONNECTION_NAME);
+    public RMQConnection getDefaultProducerConnection() {
+        return connectionRegistry.createOrGet(Constants.DEFAULT_PRODUCER_CONNECTION_NAME);
+    }
+
+    public RMQConnection getDefaultConsumerConnection() {
+        return connectionRegistry.createOrGet(Constants.DEFAULT_CONSUMER_CONNECTION_NAME);
     }
 
     protected abstract RMQConfig getConfig(T t);

--- a/src/main/java/io/appform/dropwizard/actors/actor/UnmanagedBaseActor.java
+++ b/src/main/java/io/appform/dropwizard/actors/actor/UnmanagedBaseActor.java
@@ -147,22 +147,22 @@ public class UnmanagedBaseActor<Message> {
 
     private String producerConnectionName(ProducerConfig producerConfig) {
         if (producerConfig == null) {
-            return Constants.DEFAULT_CONNECTION_NAME;
+            return Constants.DEFAULT_PRODUCER_CONNECTION_NAME;
         }
-        return deriveConnectionName(producerConfig.getConnectionIsolationStrategy());
+        return deriveConnectionName(producerConfig.getConnectionIsolationStrategy(), Constants.DEFAULT_PRODUCER_CONNECTION_NAME);
     }
 
     private String consumerConnectionName(ConsumerConfig consumerConfig) {
         if (consumerConfig == null) {
-            return Constants.DEFAULT_CONNECTION_NAME;
+            return Constants.DEFAULT_CONSUMER_CONNECTION_NAME;
         }
 
-        return deriveConnectionName(consumerConfig.getConnectionIsolationStrategy());
+        return deriveConnectionName(consumerConfig.getConnectionIsolationStrategy(), Constants.DEFAULT_CONSUMER_CONNECTION_NAME);
     }
 
-    private String deriveConnectionName(ConnectionIsolationStrategy isolationStrategy) {
+    private String deriveConnectionName(ConnectionIsolationStrategy isolationStrategy, String defaultConnectionName) {
         if (isolationStrategy == null) {
-            return Constants.DEFAULT_CONNECTION_NAME;
+            return defaultConnectionName;
         }
 
         return isolationStrategy.accept(new ConnectionIsolationStrategyVisitor<String>() {
@@ -174,7 +174,7 @@ public class UnmanagedBaseActor<Message> {
 
             @Override
             public String visit(DefaultConnectionStrategy strategy) {
-                return Constants.DEFAULT_CONNECTION_NAME;
+                return defaultConnectionName;
             }
 
         });

--- a/src/main/java/io/appform/dropwizard/actors/common/Constants.java
+++ b/src/main/java/io/appform/dropwizard/actors/common/Constants.java
@@ -6,8 +6,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class Constants {
 
-    public static final String DEFAULT_CONNECTION_NAME = "default";
+    public static final String DEFAULT_PRODUCER_CONNECTION_NAME = "defaultproducer";
 
+    public static final String DEFAULT_CONSUMER_CONNECTION_NAME = "defaultconsumer";
     public static final int DEFAULT_THREADS_PER_CONNECTION = 10;
 
     public static final int MAX_THREADS_PER_CONNECTION = 300;

--- a/src/main/java/io/appform/dropwizard/actors/common/Constants.java
+++ b/src/main/java/io/appform/dropwizard/actors/common/Constants.java
@@ -9,9 +9,9 @@ import java.util.Set;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class Constants {
 
-    public static final String DEFAULT_PRODUCER_CONNECTION_NAME = "defaultproducer";
+    public static final String DEFAULT_PRODUCER_CONNECTION_NAME = "__defaultproducer";
 
-    public static final String DEFAULT_CONSUMER_CONNECTION_NAME = "defaultconsumer";
+    public static final String DEFAULT_CONSUMER_CONNECTION_NAME = "__defaultconsumer";
 
     public static final Set<String> DEFAULT_CONNECTIONS = Sets.newHashSet(DEFAULT_PRODUCER_CONNECTION_NAME,
             DEFAULT_CONSUMER_CONNECTION_NAME);

--- a/src/main/java/io/appform/dropwizard/actors/common/Constants.java
+++ b/src/main/java/io/appform/dropwizard/actors/common/Constants.java
@@ -1,7 +1,10 @@
 package io.appform.dropwizard.actors.common;
 
+import com.google.common.collect.Sets;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+
+import java.util.Set;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class Constants {
@@ -9,6 +12,9 @@ public class Constants {
     public static final String DEFAULT_PRODUCER_CONNECTION_NAME = "defaultproducer";
 
     public static final String DEFAULT_CONSUMER_CONNECTION_NAME = "defaultconsumer";
+
+    public static final Set<String> DEFAULT_CONNECTIONS = Sets.newHashSet(DEFAULT_PRODUCER_CONNECTION_NAME,
+            DEFAULT_CONSUMER_CONNECTION_NAME);
     public static final int DEFAULT_THREADS_PER_CONNECTION = 10;
 
     public static final int MAX_THREADS_PER_CONNECTION = 300;

--- a/src/main/java/io/appform/dropwizard/actors/common/ErrorCode.java
+++ b/src/main/java/io/appform/dropwizard/actors/common/ErrorCode.java
@@ -20,5 +20,8 @@ package io.appform.dropwizard.actors.common;
  * Error codes
  */
 public enum ErrorCode {
+
+    CONNECTION_NAME_RESERVED_FOR_INTERNAL_USE,
+
     INTERNAL_ERROR
 }

--- a/src/test/java/io/appform/dropwizard/actors/ConnectionRegistryTest.java
+++ b/src/test/java/io/appform/dropwizard/actors/ConnectionRegistryTest.java
@@ -1,0 +1,61 @@
+package io.appform.dropwizard.actors;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.health.HealthCheckRegistry;
+import com.google.common.collect.Lists;
+import io.appform.dropwizard.actors.common.Constants;
+import io.appform.dropwizard.actors.common.ErrorCode;
+import io.appform.dropwizard.actors.common.RabbitmqActorException;
+import io.appform.dropwizard.actors.config.RMQConfig;
+import io.appform.dropwizard.actors.connectivity.ConnectionConfig;
+import io.dropwizard.Configuration;
+import io.dropwizard.setup.Environment;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.validation.Validation;
+import java.util.concurrent.Executors;
+
+import static org.junit.Assert.assertTrue;
+
+public class ConnectionRegistryTest {
+
+    private ConnectionRegistry registry;
+
+    private Environment environment;
+
+    @Before
+    public void setup() {
+
+        environment = new Environment("testing",
+                null,
+                Validation.buildDefaultValidatorFactory(),
+                new MetricRegistry(),
+                Thread.currentThread().getContextClassLoader(),
+                new HealthCheckRegistry(),
+                new Configuration());
+    }
+
+    @Test
+    public void testCustomConnectionCreationWithReservedNameFails() {
+        RMQConfig config = new RMQConfig();
+        config.setConnections(Lists.newArrayList(ConnectionConfig.builder().name(Constants.DEFAULT_CONSUMER_CONNECTION_NAME).build()));
+
+        registry = new ConnectionRegistry(environment,
+                (name, coreSize) -> Executors.newFixedThreadPool(1),
+                config, TtlConfig.builder().build());
+
+        Constants.DEFAULT_CONNECTIONS.forEach(defaultConnectionName -> {
+            try {
+                registry.createOrGet(defaultConnectionName);
+            } catch (Exception ex) {
+                assertTrue(ex instanceof RabbitmqActorException &&
+                        ((RabbitmqActorException) ex).getErrorCode().equals(ErrorCode.CONNECTION_NAME_RESERVED_FOR_INTERNAL_USE));
+                assertTrue(ex.getMessage().startsWith("These connection names are reserved for internal usage: ") &&
+                        ex.getMessage().contains(defaultConnectionName));
+            }
+        });
+    }
+
+
+}


### PR DESCRIPTION
In flow state, RMQ blocks the publishing connection. If consumers are using same connection, they will be unable to drain the queue, thus defeating the whole purpose of flow control. Keeping connections separate will allow only publishers to be blocked when rmq triggers flow state, and for consumers to drain the queues and recover the queue eventually by adding credits.

This is also called out as one of common mistakes developers make with RMQ

https://www.rabbitmq.com/connections.html#flow-control
https://www.cloudamqp.com/blog/part4-rabbitmq-13-common-errors.html