### PR TITLE
Open tracing capability will be added in RMQ

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.appform.dropwizard.actors</groupId>
     <artifactId>dropwizard-rabbitmq-actors</artifactId>
-    <version>2.0.28-13</version>
+    <version>2.0.28-13-Ankush</version>
     <name>Dropwizard RabbitMQ Bundle</name>
     <url>https://github.com/santanusinha/dropwizard-rabbitmq-actors</url>
     <description>Provides actor abstraction on RabbitMQ for dropwizard based projects.</description>
@@ -279,6 +279,13 @@
                         </weaveDependency>
                     </weaveDependencies>
                 </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -167,6 +167,13 @@
             <artifactId>httpclient</artifactId>
             <version>4.5.13</version>
         </dependency>
+
+        <dependency>
+            <groupId>io.appform.opentracing.annotations</groupId>
+            <artifactId>opentracing-annotations</artifactId>
+            <version>1.0.4-ankush</version>
+        </dependency>
+
         <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-testing</artifactId>
@@ -249,6 +256,31 @@
         </pluginManagement>
         <plugins>
             <plugin>
+                <groupId>dev.aspectj</groupId>
+                <artifactId>aspectj-maven-plugin</artifactId>
+                <version>1.13.1</version>
+                <configuration>
+                    <complianceLevel>17</complianceLevel>
+                    <source>17</source>
+                    <target>17</target>
+                    <showWeaveInfo>true</showWeaveInfo>
+                    <verbose>true</verbose>
+                    <Xlint>ignore</Xlint>
+                    <encoding>UTF-8</encoding>
+                    <forceAjcCompile>true</forceAjcCompile>
+                    <sources />
+                    <weaveDirectories>
+                        <weaveDirectory>${project.build.directory}/classes</weaveDirectory>
+                    </weaveDirectories>
+                    <weaveDependencies>
+                        <weaveDependency>
+                            <groupId>io.appform.opentracing.annotations</groupId>
+                            <artifactId>opentracing-annotations</artifactId>
+                        </weaveDependency>
+                    </weaveDependencies>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>0.8.8</version>
@@ -321,19 +353,19 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.3.1</version>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
+<!--            <plugin>-->
+<!--                <groupId>org.apache.maven.plugins</groupId>-->
+<!--                <artifactId>maven-javadoc-plugin</artifactId>-->
+<!--                <version>3.3.1</version>-->
+<!--                <executions>-->
+<!--                    <execution>-->
+<!--                        <id>attach-javadocs</id>-->
+<!--                        <goals>-->
+<!--                            <goal>jar</goal>-->
+<!--                        </goals>-->
+<!--                    </execution>-->
+<!--                </executions>-->
+<!--            </plugin>-->
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
@@ -345,6 +377,7 @@
                     <autoReleaseAfterClose>true</autoReleaseAfterClose>
                 </configuration>
             </plugin>
+
         </plugins>
     </build>
 

--- a/src/main/java/io/appform/dropwizard/actors/actor/BaseActor.java
+++ b/src/main/java/io/appform/dropwizard/actors/actor/BaseActor.java
@@ -24,6 +24,7 @@ import io.appform.dropwizard.actors.base.UnmanagedPublisher;
 import io.appform.dropwizard.actors.connectivity.RMQConnection;
 import io.appform.dropwizard.actors.exceptionhandler.ExceptionHandlingFactory;
 import io.appform.dropwizard.actors.retry.RetryStrategyFactory;
+import io.appform.dropwizard.actors.utils.CommonUtils;
 import io.dropwizard.lifecycle.Managed;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -109,6 +110,8 @@ public abstract class BaseActor<Message> implements Managed {
         return handle(message);
     }
 
+
+
     /*
         Override this method in your code in case you want to handle the expired messages separately
      */
@@ -142,13 +145,18 @@ public abstract class BaseActor<Message> implements Managed {
         val properties = new AMQP.BasicProperties.Builder()
                 .deliveryMode(2)
                 .timestamp(new Date())
+                .headers(CommonUtils.getTracingMap())
                 .build();
         publish(message, properties);
     }
 
+
+
     public final void publish(final Message message, final AMQP.BasicProperties properties) throws Exception {
         actorImpl.publish(message, properties);
     }
+
+
 
     public final long pendingMessagesCount() {
         return actorImpl.pendingMessagesCount();
@@ -167,4 +175,6 @@ public abstract class BaseActor<Message> implements Managed {
     public void stop() throws Exception {
         actorImpl.stop();
     }
+
+
 }

--- a/src/main/java/io/appform/dropwizard/actors/base/Handler.java
+++ b/src/main/java/io/appform/dropwizard/actors/base/Handler.java
@@ -17,14 +17,12 @@ import io.appform.dropwizard.actors.observers.ConsumeObserverContext;
 import io.appform.dropwizard.actors.observers.RMQObserver;
 import io.appform.dropwizard.actors.retry.RetryStrategy;
 import java.io.IOException;
-import java.lang.reflect.Method;
 import java.time.Instant;
 import java.util.concurrent.Callable;
 import java.util.function.Function;
 
 import io.appform.dropwizard.actors.utils.CommonUtils;
 import io.appform.opentracing.FunctionData;
-import io.appform.opentracing.util.TracerUtil;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -82,7 +80,7 @@ public class Handler<Message> extends DefaultConsumer {
                 .build();
         return observer.executeConsume(context, () -> {
             try {
-                executeTracing(messageMetadata);
+                executeTracingIfTraceIsAvailable(messageMetadata);
                 return expired
                         ? expiredMessageHandlingFunction.apply(message, messageMetadata)
                         : messageHandlingFunction.apply(message, messageMetadata);
@@ -95,10 +93,8 @@ public class Handler<Message> extends DefaultConsumer {
         });
     }
 
-    private void executeTracing(MessageMetadata messageMetadata) {
-        if(TracerUtil.isTracePresent()) {
-            CommonUtils.startTracing(messageMetadata, getFunctionalData());
-        }
+    private void executeTracingIfTraceIsAvailable(MessageMetadata messageMetadata) {
+        CommonUtils.startTracing(messageMetadata, getFunctionalData());
     }
 
 

--- a/src/main/java/io/appform/dropwizard/actors/base/Handler.java
+++ b/src/main/java/io/appform/dropwizard/actors/base/Handler.java
@@ -23,6 +23,7 @@ import java.util.function.Function;
 
 import io.appform.dropwizard.actors.utils.CommonUtils;
 import io.appform.opentracing.FunctionData;
+import io.appform.opentracing.util.TracerUtil;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -89,6 +90,7 @@ public class Handler<Message> extends DefaultConsumer {
                 throw RabbitmqActorException.propagate(e);
             } finally {
                 running = false;
+                TracerUtil.destroyTracingForRequest();
             }
         });
     }

--- a/src/main/java/io/appform/dropwizard/actors/base/Handler.java
+++ b/src/main/java/io/appform/dropwizard/actors/base/Handler.java
@@ -24,6 +24,7 @@ import java.util.function.Function;
 
 import io.appform.dropwizard.actors.utils.CommonUtils;
 import io.appform.opentracing.FunctionData;
+import io.appform.opentracing.util.TracerUtil;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -81,7 +82,7 @@ public class Handler<Message> extends DefaultConsumer {
                 .build();
         return observer.executeConsume(context, () -> {
             try {
-                CommonUtils.startTracing(messageMetadata, getFunctionalData());
+                executeTracing(messageMetadata);
                 return expired
                         ? expiredMessageHandlingFunction.apply(message, messageMetadata)
                         : messageHandlingFunction.apply(message, messageMetadata);
@@ -94,6 +95,11 @@ public class Handler<Message> extends DefaultConsumer {
         });
     }
 
+    private void executeTracing(MessageMetadata messageMetadata) {
+        if(TracerUtil.isTracePresent()) {
+            CommonUtils.startTracing(messageMetadata, getFunctionalData());
+        }
+    }
 
 
     @Override

--- a/src/main/java/io/appform/dropwizard/actors/base/UnmanagedPublisher.java
+++ b/src/main/java/io/appform/dropwizard/actors/base/UnmanagedPublisher.java
@@ -20,6 +20,10 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Map;
+
+import io.appform.dropwizard.actors.utils.CommonUtils;
+import io.appform.opentracing.util.TracerUtil;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.RandomUtils;
@@ -81,6 +85,7 @@ public class UnmanagedPublisher<Message> {
     public final void publishWithExpiry(final Message message, final long expiryInMs) throws Exception {
         AMQP.BasicProperties properties = new AMQP.BasicProperties.Builder()
                 .deliveryMode(2)
+                .headers(CommonUtils.getTracingMap())
                 .build();
         val finalProperties = getPropertiesWithExpiry(properties, expiryInMs);
         publish(message, finalProperties);
@@ -136,10 +141,12 @@ public class UnmanagedPublisher<Message> {
             return new AMQP.BasicProperties.Builder()
                     .expiration(String.valueOf(delayMilliseconds))
                     .deliveryMode(2)
+                    .headers(CommonUtils.getTracingMap())
                     .build();
         }
             return new AMQP.BasicProperties.Builder()
                     .headers(Collections.singletonMap("x-delay", delayMilliseconds))
+                    .headers(CommonUtils.getTracingMap())
                     .deliveryMode(2)
                     .build();
     }
@@ -149,8 +156,9 @@ public class UnmanagedPublisher<Message> {
             return properties;
         }
         val expiresAt = Instant.now().toEpochMilli() + expiryInMs;
+        Map<String, Object> headers = ImmutableMap.<String, Object>builder().putAll(CommonUtils.getTracingMap()).put(MESSAGE_EXPIRY_TEXT, expiresAt).build();
         return new AMQP.BasicProperties.Builder()
-                .headers(ImmutableMap.of(MESSAGE_EXPIRY_TEXT, expiresAt))
+                .headers(headers)
                 .build();
     }
 

--- a/src/main/java/io/appform/dropwizard/actors/utils/CommonUtils.java
+++ b/src/main/java/io/appform/dropwizard/actors/utils/CommonUtils.java
@@ -57,7 +57,9 @@ public class CommonUtils {
                 .headers(messageMetadata.getHeaders())
                 .build();
         TracerUtil.populateTracingFromQueue(properties);
-        TracerUtil.populateMDCTracing(TracingHandler.startSpan(functionData, ""));
+        if(TracerUtil.isTracePresent()) {
+            TracerUtil.populateMDCTracing(TracingHandler.startSpan(functionData, ""));
+        }
     }
 
 

--- a/src/main/java/io/appform/dropwizard/actors/utils/CommonUtils.java
+++ b/src/main/java/io/appform/dropwizard/actors/utils/CommonUtils.java
@@ -57,7 +57,7 @@ public class CommonUtils {
                 .headers(messageMetadata.getHeaders())
                 .build();
         TracerUtil.populateTracingFromQueue(properties);
-        TracingHandler.startSpan(functionData, "");
+        TracerUtil.populateMDCTracing(TracingHandler.startSpan(functionData, ""));
     }
 
 

--- a/src/main/java/io/appform/dropwizard/actors/utils/CommonUtils.java
+++ b/src/main/java/io/appform/dropwizard/actors/utils/CommonUtils.java
@@ -17,17 +17,14 @@
 package io.appform.dropwizard.actors.utils;
 
 import com.google.common.base.Strings;
-import com.rabbitmq.client.AMQP;
 import io.appform.dropwizard.actors.actor.MessageMetadata;
 import io.appform.opentracing.FunctionData;
 import io.appform.opentracing.TracingHandler;
 import io.appform.opentracing.util.TracerUtil;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import lombok.val;
 
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -53,10 +50,7 @@ public class CommonUtils {
     }
 
     public static void startTracing(MessageMetadata messageMetadata, final FunctionData functionData) {
-        val properties = new AMQP.BasicProperties.Builder()
-                .headers(messageMetadata.getHeaders())
-                .build();
-        TracerUtil.populateTracingFromQueue(properties);
+        TracerUtil.populateTracingFromQueue(messageMetadata.getHeaders());
         if(TracerUtil.isTracePresent()) {
             TracerUtil.populateMDCTracing(TracingHandler.startSpan(functionData, ""));
         }

--- a/src/main/java/io/appform/dropwizard/actors/utils/CommonUtils.java
+++ b/src/main/java/io/appform/dropwizard/actors/utils/CommonUtils.java
@@ -17,10 +17,17 @@
 package io.appform.dropwizard.actors.utils;
 
 import com.google.common.base.Strings;
+import com.rabbitmq.client.AMQP;
+import io.appform.dropwizard.actors.actor.MessageMetadata;
+import io.appform.opentracing.FunctionData;
+import io.appform.opentracing.TracingHandler;
+import io.appform.opentracing.util.TracerUtil;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import lombok.val;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -44,4 +51,22 @@ public class CommonUtils {
                 || (null != exception
                 && retriableExceptions.contains(exception.getClass().getSimpleName()));
     }
+
+    public static void startTracing(MessageMetadata messageMetadata, final FunctionData functionData) {
+        val properties = new AMQP.BasicProperties.Builder()
+                .headers(messageMetadata.getHeaders())
+                .build();
+        TracerUtil.populateTracingFromQueue(properties);
+        TracingHandler.startSpan(functionData, "");
+    }
+
+
+    public static Map<String, Object> getTracingMap() {
+        if(TracerUtil.isTracePresent()) {
+            return Map.of(TracerUtil.TRACE_ID, TracerUtil.getMDCTraceId(), TracerUtil.SPAN_ID, TracerUtil.getMDCSpanId());
+        }
+        return Map.of();
+    }
+
+
 }

--- a/src/test/java/io/appform/dropwizard/actors/connectivity/actor/ExpiryMessagesTest.java
+++ b/src/test/java/io/appform/dropwizard/actors/connectivity/actor/ExpiryMessagesTest.java
@@ -18,10 +18,6 @@ import io.appform.dropwizard.actors.retry.RetryStrategyFactory;
 import io.appform.dropwizard.actors.retry.config.CountLimitedFixedWaitRetryConfig;
 import io.appform.dropwizard.actors.utils.RMQContainer;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
-import java.util.ArrayList;
-import java.util.Map;
-import java.util.concurrent.Executors;
-import java.util.concurrent.atomic.AtomicInteger;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
@@ -31,6 +27,11 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.RabbitMQContainer;
+
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
 
 @Slf4j
 public class ExpiryMessagesTest {


### PR DESCRIPTION
- Tracing capability will be added once the message is pushed and consumed
- No need to have any additional changes related to config
- This MR is tested with use cases mentioned below
     -  Message pushed when Trace was present, Trace automatically plugged into actors and consumer able to process tracing from that trace
     - Message pushed when Trace was not present, no tracing is visible across the consumers 
    