### PR TITLE
Ensuring main exchange is created in case of TTL queues

### DIFF
--- a/src/main/java/io/appform/dropwizard/actors/base/UnmanagedPublisher.java
+++ b/src/main/java/io/appform/dropwizard/actors/base/UnmanagedPublisher.java
@@ -197,9 +197,8 @@ public class UnmanagedPublisher<Message> {
         final String dlx = NamingUtils.getSideline(config.getExchange());
         if (config.isDelayed()) {
             ensureDelayedExchange(exchange);
-        } else {
-            ensureExchange(exchange);
         }
+        ensureExchange(exchange);
         ensureExchange(dlx);
 
         this.publishChannel = connection.newChannel();

--- a/src/main/java/io/appform/dropwizard/actors/base/UnmanagedPublisher.java
+++ b/src/main/java/io/appform/dropwizard/actors/base/UnmanagedPublisher.java
@@ -197,8 +197,9 @@ public class UnmanagedPublisher<Message> {
         final String dlx = NamingUtils.getSideline(config.getExchange());
         if (config.isDelayed()) {
             ensureDelayedExchange(exchange);
+        } else {
+            ensureExchange(exchange);
         }
-        ensureExchange(exchange);
         ensureExchange(dlx);
 
         this.publishChannel = connection.newChannel();
@@ -233,6 +234,7 @@ public class UnmanagedPublisher<Message> {
     private void ensureDelayedExchange(String exchange) throws IOException {
         if (config.getDelayType() == DelayType.TTL) {
             ensureExchange(ttlExchange(config));
+            ensureExchange(exchange);
         } else {
             // https://blog.rabbitmq.com/posts/2015/04/scheduling-messages-with-rabbitmq/
             connection.channel().exchangeDeclare(

--- a/src/test/java/io/appform/dropwizard/actors/RabbitmqActorBundleTest.java
+++ b/src/test/java/io/appform/dropwizard/actors/RabbitmqActorBundleTest.java
@@ -26,7 +26,6 @@ import org.mockito.Mockito;
 import java.time.Duration;
 import java.util.ArrayList;
 
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 


### PR DESCRIPTION
There is issue while creating exchanges for Exchange Type : TTL

Below are the exchanges that are created 
1. Exchange
2. Exchange_TTL
3. Exchange_SIDELINE

Currently it is creating only two exchanges, _TTL and _SIDELINE and not the main exchange.